### PR TITLE
[feat] use progress indicator button and block button before finish

### DIFF
--- a/evac_app/lib/components/button_stagger_animation.dart
+++ b/evac_app/lib/components/button_stagger_animation.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+
+class ButtonStaggerAnimation extends StatelessWidget {
+  // Animation fields
+  final  controller;
+
+  // Display fields
+  final Color? color;
+  final Color? progressIndicatorColor;
+  final double? progressIndicatorSize;
+  final BorderRadius? borderRadius;
+  final double strokeWidth;
+  final Function(AnimationController)? onPressed;
+  final Widget? child;
+
+  ButtonStaggerAnimation({
+    Key? key,
+    this.controller,
+    this.color,
+    this.progressIndicatorColor,
+    this.progressIndicatorSize,
+    this.borderRadius,
+    this.onPressed,
+    this.strokeWidth = 0.0,
+    this.child,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(builder: _progressAnimatedBuilder);
+  }
+
+  Widget? _buttonChild() {
+    if (controller!.isAnimating) {
+      return Container();
+    } else if (controller!.isCompleted) {
+      return OverflowBox(
+        maxWidth: progressIndicatorSize,
+        maxHeight: progressIndicatorSize,
+        child: CircularProgressIndicator(
+          strokeWidth: strokeWidth,
+          valueColor: AlwaysStoppedAnimation<Color>(progressIndicatorColor!),
+        ),
+      );
+    }
+    return child;
+  }
+
+  AnimatedBuilder _progressAnimatedBuilder(
+      BuildContext context, BoxConstraints constraints) {
+    var buttonHeight = (constraints.maxHeight != double.infinity)
+        ? constraints.maxHeight
+        : 60.0;
+
+    var widthAnimation = Tween<double>(
+      begin: constraints.maxWidth,
+      end: buttonHeight,
+    ).animate(
+      CurvedAnimation(
+        parent: controller,
+        curve: Curves.easeInOut,
+      ),
+    );
+
+    var borderRadiusAnimation = Tween<BorderRadius>(
+      begin: borderRadius,
+      end: BorderRadius.all(Radius.circular(buttonHeight / 2.0)),
+    ).animate(CurvedAnimation(
+      parent: controller,
+      curve: Curves.easeInOut,
+    ));
+
+    return AnimatedBuilder(
+      animation: controller,
+      builder: (context, child) {
+        return SizedBox(
+          height: buttonHeight,
+          width: widthAnimation.value,
+          child: RaisedButton(
+            shape: RoundedRectangleBorder(
+              borderRadius: borderRadiusAnimation.value,
+            ),
+            color: color,
+            child: _buttonChild(),
+            onPressed: () {
+              this.onPressed!(controller);
+            },
+          ),
+        );
+      },
+    );
+  }
+}

--- a/evac_app/lib/components/progress_button.dart
+++ b/evac_app/lib/components/progress_button.dart
@@ -1,0 +1,79 @@
+library progress_button;
+
+import 'package:flutter/material.dart';
+
+import 'button_stagger_animation.dart';
+
+class ProgressButton extends StatefulWidget {
+  /// The background color of the button.
+  final Color color;
+  /// The progress indicator color.
+  final Color progressIndicatorColor;
+  /// The size of the progress indicator.
+  final double progressIndicatorSize;
+  /// The border radius while NOT animating.
+  final BorderRadius borderRadius;
+  /// The duration of the animation.
+  final Duration animationDuration;
+
+  /// The stroke width of progress indicator.
+  final double strokeWidth;
+  /// Function that will be called at the on pressed event.
+  ///
+  /// This will grant access to its [AnimationController] so
+  /// that the animation can be controlled based on the need.
+  final Function(AnimationController)? onPressed;
+  /// The child to display on the button.
+  final Widget? child;
+
+  ProgressButton({
+    @required this.child,
+    @required this.onPressed,
+    this.color = Colors.blue,
+    this.strokeWidth = 2,
+    this.progressIndicatorColor = Colors.white,
+    this.progressIndicatorSize = 30,
+    this.borderRadius = const BorderRadius.all(Radius.circular(0)),
+    this.animationDuration = const Duration(milliseconds: 300),
+  });
+
+  @override
+  _ProgressButtonState createState() => _ProgressButtonState();
+}
+
+class _ProgressButtonState extends State<ProgressButton>
+    with TickerProviderStateMixin {
+  var _controller;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _controller = AnimationController(
+      duration: widget.animationDuration,
+      vsync: this,
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ButtonStaggerAnimation(
+        controller: _controller.view,
+        color: widget.color,
+        strokeWidth: widget.strokeWidth,
+        progressIndicatorColor: widget.progressIndicatorColor,
+        progressIndicatorSize: widget.progressIndicatorSize,
+        borderRadius: widget.borderRadius,
+        onPressed: widget.onPressed,
+        child: widget.child,
+      ),
+    );
+  }
+}

--- a/evac_app/lib/pages/invite_code_page.dart
+++ b/evac_app/lib/pages/invite_code_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:evac_app/components/evac_app_scaffold.dart';
+import '../components/progress_button.dart';
 
 class InviteCodePage extends StatefulWidget {
   const InviteCodePage({
@@ -16,6 +17,9 @@ class InviteCodePage extends StatefulWidget {
 
 class _InviteCodePageState extends State<InviteCodePage> {
   final _formKey = GlobalKey<FormState>();
+  String inviteCode = '';
+  bool _isLoading = false;
+
   @override
   Widget build(BuildContext context) {
     return EvacAppScaffold(
@@ -39,18 +43,39 @@ class _InviteCodePageState extends State<InviteCodePage> {
                   return 'error: code must be 6 digits';
                 }
               },
-              onSaved: (value) => _tryCode(context, value),
+              onSaved: (value) => {this.inviteCode = value!},
               decoration: const InputDecoration(
                 border: OutlineInputBorder(),
                 labelText: 'Invite Code',
               ),
             ),
-            ElevatedButton(
-                onPressed: () {
-                  if (_formKey.currentState!.validate())
-                    _formKey.currentState!.save();
-                },
-                child: Text('enter')),
+            Align(
+                alignment: Alignment.bottomRight,
+                child: Container(
+                  width: 100,
+                  height: 40,
+                  margin: const EdgeInsets.only(top: 10.0),
+                  child: ProgressButton(
+                    borderRadius: BorderRadius.all(Radius.circular(4)),
+                    strokeWidth: 2,
+                    child: Text(
+                      "Enter",
+                    ),
+                    onPressed: (AnimationController controller) async {
+                      if (_formKey.currentState!.validate()) {
+                        _formKey.currentState!.save();
+                        if (!_isLoading) {
+                          _isLoading = true;
+                          controller.forward();
+                          await _tryCode(context, inviteCode);
+                          controller.reset();
+                          _isLoading = false;
+                        }
+                      }
+                    },
+                    color: Color.fromARGB(0xa0, 0xff, 0xa5, 0x00),
+                  ),
+                ))
           ]),
         ),
       ),

--- a/evac_app/pubspec.yaml
+++ b/evac_app/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   json_annotation: ^4.0.1
   location: ^4.3.0
   path_provider: ^2.0.4
-  permission_handler: ^8.3.0
+  permission_handler: ^9.2.0
   survey_kit:
     git:
       url: https://github.com/kaff-oregonstate/survey_kit
@@ -46,7 +46,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  json_serializable: ^4.1.4
+  json_serializable: ^6.1.5
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
## Feat:

- Use the progress_indicator_button when entering the invite code
- Block this button when the last request is not finished

## Notes

- Why not use `flutter pub add`: this library is not "null safe". Adding this will make our project unable to compile. So I made a few changes to this library and included the source code directly in our repo.