### PR TITLE
Location tracking clear cache

### DIFF
--- a/evac_app/lib/db/trajectory_database_manager.dart
+++ b/evac_app/lib/db/trajectory_database_manager.dart
@@ -57,7 +57,7 @@ class TrajectoryDatabaseManager {
 
   Future<void> wipeData() async {
     await deleteDatabase(_DATABASE_FILENAME);
-    return initialize();
+    return await initialize();
   }
 
   static void createTables(Database db, String sql) async {

--- a/evac_app/lib/location_tracking/location_tracker.dart
+++ b/evac_app/lib/location_tracking/location_tracker.dart
@@ -29,7 +29,8 @@ class LocationTracker {
       String result = await canUseLocation();
       if (result == 'yes') {
         print('location available');
-        // clearing previous data:
+        // clearing previous data
+        // #88: this could be moved to "Aquire GPS Signal"
         await _clearDB(_databaseManager);
         // getting location stream:
         _locationService = LocationService();

--- a/evac_app/lib/location_tracking/location_tracker.dart
+++ b/evac_app/lib/location_tracking/location_tracker.dart
@@ -29,6 +29,9 @@ class LocationTracker {
       String result = await canUseLocation();
       if (result == 'yes') {
         print('location available');
+        // clearing previous data:
+        await _clearDB(_databaseManager);
+        // getting location stream:
         _locationService = LocationService();
         // this line makes sure that if a second drill is run while app is still
         // open, the data from the end of the last drill is not erroneously put


### PR DESCRIPTION
Clear the location cache on tracking start (`startLogging()`), so that data saved before app crash/close doesn't get erroneously prepended to newly gathered data.